### PR TITLE
Fixing pagination rel

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -108,9 +108,8 @@ module WillPaginate
 
       def rel_value(page)
         case page
-        when @collection.current_page - 1; 'prev' + (page == 1 ? ' start' : '')
+        when @collection.current_page - 1; 'prev'
         when @collection.current_page + 1; 'next'
-        when 1; 'start'
         end
       end
 

--- a/spec/view_helpers/action_view_spec.rb
+++ b/spec/view_helpers/action_view_spec.rb
@@ -80,9 +80,9 @@ describe WillPaginate::ActionView do
         validate_page_numbers [1,1,3,3], elements
         # test rel attribute values:
         text(elements[0]).should == 'Prev'
-        elements[0]['rel'].should == 'prev start'
+        elements[0]['rel'].should == 'prev'
         text(elements[1]).should == '1'
-        elements[1]['rel'].should == 'prev start'
+        elements[1]['rel'].should == 'prev'
         text(elements[3]).should == 'Next'
         elements[3]['rel'].should == 'next'
       end


### PR DESCRIPTION
This PR fixes a minor issue: when a user is on the second page, the link to first page incorrectly shows a rel = prev start relation.

Update: I've actually removed the rel=start relation in accordance to this guide: https://moz.com/ugc/seo-guide-to-google-webmaster-recommendations-for-pagination
